### PR TITLE
Standardizing code base strings on double quotes instead of a mix.

### DIFF
--- a/quince/components/__init__.py
+++ b/quince/components/__init__.py
@@ -12,7 +12,7 @@ as they collect cards on their turns.
 Player - A player of the game.
 """
 
-__all__ = ['Card', 'Deck', 'Pila', 'Player', 'NPC']
+__all__ = ["Card", "Deck", "Pila", "Player", "NPC"]
 
 from quince.components.card import Card
 from quince.components.deck import Deck

--- a/quince/components/card.py
+++ b/quince/components/card.py
@@ -20,7 +20,7 @@ class Card(object):
             suit (str) -- Card suit
         """
         if number < 1 or number > 10:
-            raise ValueError('Cards can only be between 1 and 10')
+            raise ValueError("Cards can only be between 1 and 10")
 
         self._number = number
         self.number = number
@@ -31,7 +31,7 @@ class Card(object):
         if img_num >= 8:
             img_num += 2
 
-        self._image = f'quince/assets/img/card_{suit}_{img_num}.png'
+        self._image = f"quince/assets/img/card_{suit}_{img_num}.png"
 
         setenta = [11.0, 4.0, 6.0, 8.0, 10.0, 14.0, 17.5, 1, 1, 1]
         self.points_setenta = setenta[number - 1]
@@ -64,5 +64,5 @@ class Card(object):
         return Card(self.number, self.suit)
 
     def __hash__(self):
-        hashable = f'{self.number}{self.suit}'
+        hashable = f"{self.number}{self.suit}"
         return hash(hashable)

--- a/quince/components/deck.py
+++ b/quince/components/deck.py
@@ -37,7 +37,7 @@ class Deck(object):
         for i in range(0, 10):
             # Sotas, caballos, and reyes are represented
             # using their real value, not their face number
-            for suit in ['oro', 'basto', 'espada', 'copa']:
+            for suit in ["oro", "basto", "espada", "copa"]:
                 new_card = self._card_type(i + 1, suit)
                 self._cards.append(new_card)
 
@@ -45,10 +45,10 @@ class Deck(object):
         random.shuffle(self._cards)
 
     def __str__(self):
-        return f'Deck containing {len(self.cards())} Cards.'
+        return f"Deck containing {len(self.cards())} Cards."
 
     def __repr__(self):
-        return f'Deck containing {len(self.cards())} Cards.'
+        return f"Deck containing {len(self.cards())} Cards."
 
     def cards(self):
         """Returns a copy of the list of cards in the deck.
@@ -56,8 +56,8 @@ class Deck(object):
         return [x.clone() for x in self._cards]
 
     def deal(self, amount):
-        """Removes cards from the deck and returns a tuple containing a new deck
-        and the hand that was dealt.
+        """Removes cards from the deck and returns a tuple containing a new
+        deck and the hand that was dealt.
 
         Args:
             amount (int) -- Amount of cards to deal

--- a/quince/components/pila.py
+++ b/quince/components/pila.py
@@ -26,7 +26,7 @@ class Pila(object):
             cards -- Dictionary of cards with which to instantiate the pile
         """
         if cards is None:
-            self._cards = {'oro': [], 'basto': [], 'espada': [], 'copa': []}
+            self._cards = {"oro": [], "basto": [], "espada": [], "copa": []}
         else:
             self._cards = deepcopy(cards)
 
@@ -94,7 +94,7 @@ class Pila(object):
     def has_siete_de_velo(self):
         """Returns True if the pila contains the 7 of oro
         """
-        for card in self._cards['oro']:
+        for card in self._cards["oro"]:
             if card.info()[0] == 7:
                 return True
 
@@ -112,4 +112,4 @@ class Pila(object):
     def total_oros(self):
         """Returns the total number of oros that the user has picked up.
         """
-        return len(self._cards['oro'])
+        return len(self._cards["oro"])

--- a/quince/components/player.py
+++ b/quince/components/player.py
@@ -18,7 +18,7 @@ class Player(object):
     """
 
     internal_id = 0
-    names_list = ['Alicia', 'Felipe', 'Mariana', 'Pepe', 'Juanita', 'Timoteo']
+    names_list = ["Alicia", "Felipe", "Mariana", "Pepe", "Juanita", "Timoteo"]
 
     def __init__(self, name=None, image_path=None):
         """Instantiates a player for the game.
@@ -50,14 +50,14 @@ class Player(object):
 
         self._total_score = 0
 
-        default_img = f'quince/ui/assets/avatars/{self.name().lower()}.png'
+        default_img = f"quince/ui/assets/avatars/{self.name().lower()}.png"
         self.image_path = default_img if image_path is None else image_path
 
     def __repr__(self):
-        return f'Player, {self.name()}.'
+        return f"Player, {self.name()}."
 
     def __str__(self):
-        return f'Player, {self.name()}.'
+        return f"Player, {self.name()}."
 
     @property
     def id(self):
@@ -76,14 +76,14 @@ class Player(object):
 
         # fallback in case a relative path was passed in
         if not os.path.exists(path):
-            print('WARNING: Passing relative paths is deprecated \
-                  and will cause errors in future releases.')
+            print("WARNING: Passing relative paths is deprecated \
+                  and will cause errors in future releases.")
             path = os.path.join(os.getcwd(), self.image_path)
 
         if not os.path.exists(path):
             # to do: replace with a proper stock image
             path = os.path.join(os.getcwd(),
-                                'quince/ui/assets/avatars/avatar01.png')
+                                "quince/ui/assets/avatars/avatar01.png")
 
         return Image.open(path)
 

--- a/quince/cpu.py
+++ b/quince/cpu.py
@@ -18,13 +18,13 @@ def enumerate_possibilities(mesa, hand):
 
     Example:
         >>> from quince.components.card import Card
-        >>> card1 = Card(1, 'oro')
-        >>> card2 = Card(9, 'espada')
-        >>> card3 = Card(2, 'oro')
-        >>> card4 = Card(4, 'copa')
-        >>> card5 = Card(3, 'copa')
-        >>> card6 = Card(2, 'basto')
-        >>> card7 = Card(5, 'espada')
+        >>> card1 = Card(1, "oro")
+        >>> card2 = Card(9, "espada")
+        >>> card3 = Card(2, "oro")
+        >>> card4 = Card(4, "copa")
+        >>> card5 = Card(3, "copa")
+        >>> card6 = Card(2, "basto")
+        >>> card7 = Card(5, "espada")
 
         >>> mesa = [card1, card2, card3, card4]
         >>> hand = [card5, card6, card7]

--- a/quince/ronda/__init__.py
+++ b/quince/ronda/__init__.py
@@ -10,8 +10,8 @@ Once a ronda is finished, the points for that ronda
 can be calculated.
 """
 
-__all__ = ['PointsCounter', 'SetentaCounter', 'SetentaWinner',
-           'Ronda', 'RondaFinishedError', 'RondaNotFinishedError']
+__all__ = ["PointsCounter", "SetentaCounter", "SetentaWinner",
+           "Ronda", "RondaFinishedError", "RondaNotFinishedError"]
 
 from quince.ronda.points_counters import (PointsCounter,
                                           SetentaCounter,

--- a/quince/ronda/points_counters.py
+++ b/quince/ronda/points_counters.py
@@ -97,7 +97,7 @@ class SetentaWinner(object):
         return self._points
 
     def __repr__(self):
-        return f'{self.player} has {self.points} setenta pts.'
+        return f"{self.player} has {self.points} setenta pts."
 
     def __str__(self):
-        return f'{self.player} has {self.points} setenta pts.'
+        return f"{self.player} has {self.points} setenta pts."

--- a/quince/ronda/ronda.py
+++ b/quince/ronda/ronda.py
@@ -43,14 +43,14 @@ def deal_to_players(players, deck):
         deck -- Deck object
 
     Returns:
-        Dictionary with players as keys, and 'hand' and 'pila' keys.
+        Dictionary with players as keys, and "hand" and "pila" keys.
     """
     player_cards = {}
     for player in players:
         (deck, hand) = deck.deal(3)
         player_cards[player] = {
-            'hand': hand,
-            'pila': Pila()
+            "hand": hand,
+            "pila": Pila()
         }
 
     return (player_cards, deck)
@@ -83,8 +83,8 @@ def remove_card_from_hand(player, card, player_cards):
         from that player's hand.
     """
     new_dict = deepcopy(player_cards)
-    new_dict[player]['hand'] = remove_cards_from_list([card],
-                                                      new_dict[player]['hand'])
+    new_dict[player]["hand"] = remove_cards_from_list([card],
+                                                      new_dict[player]["hand"])
     return new_dict
 
 
@@ -114,7 +114,7 @@ def add_cards_to_pila(player, player_cards, cards, is_escoba):
         Copy of the player_cards dictionary.
     """
     new_dict = deepcopy(player_cards)
-    new_dict[player]['pila'] = new_dict[player]['pila'].add(cards, is_escoba)
+    new_dict[player]["pila"] = new_dict[player]["pila"].add(cards, is_escoba)
     return new_dict
 
 
@@ -138,13 +138,13 @@ class Ronda(object):
             players - Ordered list of Player (used to track whose turn is next)
             player_cards - Dictionary of Cards belonging to each player
         """
-        self.current_player = kwargs.get('current_player', None)
-        self._dealer = kwargs.get('dealer', None)
-        self.deck = kwargs.get('deck', None)
-        self._last_picked_up = kwargs.get('last_pickup', None)
-        self._mesa = kwargs.get('mesa', None)
-        self._players = kwargs.get('players', [])
-        self._player_cards = kwargs.get('player_cards', None)
+        self.current_player = kwargs.get("current_player", None)
+        self._dealer = kwargs.get("dealer", None)
+        self.deck = kwargs.get("deck", None)
+        self._last_picked_up = kwargs.get("last_pickup", None)
+        self._mesa = kwargs.get("mesa", None)
+        self._players = kwargs.get("players", [])
+        self._player_cards = kwargs.get("player_cards", None)
 
         # If the entire ronda is done
         if self.is_finished:
@@ -158,8 +158,8 @@ class Ronda(object):
         elif self._hand_is_done:
             (player_cards, deck) = deal_to_players(self._players, self.deck)
             for player in self._player_cards.keys():
-                player_cards[player]['pila'] = \
-                    self._player_cards[player]['pila']
+                player_cards[player]["pila"] = \
+                    self._player_cards[player]["pila"]
             self._player_cards = player_cards
             self.deck = deck
 
@@ -183,20 +183,20 @@ class Ronda(object):
 
         if sum([card.number for card in table_deal]) == 15:
             # transfer the cards directly to the dealer's pila
-            player_cards[dealer]['pila'] = player_cards[dealer]['pila'] \
+            player_cards[dealer]["pila"] = player_cards[dealer]["pila"] \
                                             .add(table_deal)
             mesa = []
         else:
             mesa = table_deal
 
         attributes = {
-            'current_player': get_next_player(players, dealer),
-            'dealer': dealer,
-            'deck': deck,
-            'last_pickup': dealer,
-            'mesa': mesa,
-            'players': players,
-            'player_cards': player_cards
+            "current_player": get_next_player(players, dealer),
+            "dealer": dealer,
+            "deck": deck,
+            "last_pickup": dealer,
+            "mesa": mesa,
+            "players": players,
+            "player_cards": player_cards
         }
 
         return cls(**attributes)
@@ -286,14 +286,14 @@ class Ronda(object):
             self._last_picked_up = self.current_player
 
         attributes = {
-            'current_player': get_next_player(self._players,
+            "current_player": get_next_player(self._players,
                                               self.current_player),
-            'dealer': self.dealer,
-            'deck': self.deck,
-            'last_pickup': self._last_picked_up,
-            'mesa': new_mesa,
-            'players': self._players,
-            'player_cards': new_player_cards
+            "dealer": self.dealer,
+            "deck": self.deck,
+            "last_pickup": self._last_picked_up,
+            "mesa": new_mesa,
+            "players": self._players,
+            "player_cards": new_player_cards
         }
 
         return Ronda(**attributes)
@@ -302,7 +302,7 @@ class Ronda(object):
     def _hand_is_done(self):
         """Returns True if all players currently have empty hands."""
         for val in self._player_cards.values():
-            if val['hand']:
+            if val["hand"]:
                 return False
         return True
 
@@ -323,22 +323,22 @@ class Ronda(object):
 
         Returns:
             Dictionary containing records for each of the 5 types of scores.
-            'most_cards' is a tuple ([players tied for 1st place], card_count)
-            'most_oros' is a tuple ([players tied for 1st place], card_count)
-            'setenta' is a list of Setenta winner objects
-            '7_de_velo' is a reference to the player who obtained the 7
-            'escobas' is a list of tuples (player, escobas_count)
+            "most_cards" is a tuple ([players tied for 1st place], card_count)
+            "most_oros" is a tuple ([players tied for 1st place], card_count)
+            "setenta" is a list of Setenta winner objects
+            "7_de_velo" is a reference to the player who obtained the 7
+            "escobas" is a list of tuples (player, escobas_count)
         """
         most_cards = PointsCounter()
         most_oros = PointsCounter()
         setenta = SetentaCounter()
 
         ronda_points = {
-            'escobas': []
+            "escobas": []
         }
 
         for player in self._player_cards:
-            pila = self._player_cards[player]['pila']
+            pila = self._player_cards[player]["pila"]
             most_cards.compare(player, pila.total_cards())
 
             most_oros.compare(player, pila.total_oros())
@@ -347,15 +347,15 @@ class Ronda(object):
             setenta.compare(player, pila.best_setenta())
 
             if pila.has_siete_de_velo():
-                ronda_points['7_de_velo'] = player
+                ronda_points["7_de_velo"] = player
 
             escobas = pila.get_escobas()
             if escobas > 0:
-                ronda_points['escobas'].append((player, escobas))
+                ronda_points["escobas"].append((player, escobas))
 
-        ronda_points['most_cards'] = (most_cards.winners, most_cards.top_score)
-        ronda_points['most_oros'] = (most_oros.winners, most_oros.top_score)
-        ronda_points['setenta'] = setenta.winners
+        ronda_points["most_cards"] = (most_cards.winners, most_cards.top_score)
+        ronda_points["most_oros"] = (most_oros.winners, most_oros.top_score)
+        ronda_points["setenta"] = setenta.winners
 
         return ronda_points
 

--- a/quince/rondarunner.py
+++ b/quince/rondarunner.py
@@ -21,9 +21,9 @@ def get_mesa_cards(empty_mesa=False):
 
     while True:
         try:
-            usr_input = input('What cards would you like to pick up? ' +
-                              '(array of integers, or "drop" to drop): ')
-            if usr_input != 'drop' and usr_input != '':
+            usr_input = input("What cards would you like to pick up? " +
+                              "(array of integers, or 'drop' to drop): ")
+            if usr_input != "drop" and usr_input != "":
                 mesa_card_choices = literal_eval(usr_input)
                 mesa_cards = [MESA[n-1] for n in mesa_card_choices]
             else:
@@ -31,7 +31,7 @@ def get_mesa_cards(empty_mesa=False):
                 print(">>> Dropped card on the table")
             return mesa_cards
         except (ValueError, IndexError):
-            print('Invalid entry.')
+            print("Invalid entry.")
 
 
 def getchoices(current_hand, current_mesa):
@@ -39,12 +39,12 @@ def getchoices(current_hand, current_mesa):
     own_card = None
     mesa_cards = []
     while True:
-        card_choice = int(input('what card will you play? (integer): '))
+        card_choice = int(input("what card will you play? (integer): "))
         try:
             own_card = current_hand[card_choice - 1]
             break
         except (ValueError, IndexError):
-            print('Invalid entry.')
+            print("Invalid entry.")
 
     # select cards from mesa
     while True:
@@ -52,65 +52,65 @@ def getchoices(current_hand, current_mesa):
             mesa_cards = get_mesa_cards(current_mesa == [])
             break
         except ValueError:
-            print('Invalid entry.')
+            print("Invalid entry.")
 
     return (own_card, mesa_cards)
 
 
-ALICE = Player('Alice')
-BOB = NPC('Bob')
-CHARLIE = NPC('Charlie')
-DAVE = NPC('Dave')
+ALICE = Player("Alice")
+BOB = NPC("Bob")
+CHARLIE = NPC("Charlie")
+DAVE = NPC("Dave")
 
 RONDA = Ronda.start([ALICE, BOB, CHARLIE, DAVE], BOB)
 
-print('///////////////////////////')
-print('     Dealing cards . . .')
-print('///////////////////////////')
+print("///////////////////////////")
+print("     Dealing cards . . .")
+print("///////////////////////////")
 
 while not RONDA.is_finished:
 
     # Display the current status
     PLAYER = RONDA.current_player
     PLAYERNAME = PLAYER.name()
-    print(PLAYERNAME + ' holds the following cards:')
-    HAND = RONDA.player_cards[PLAYER]['hand']
+    print(PLAYERNAME + " holds the following cards:")
+    HAND = RONDA.player_cards[PLAYER]["hand"]
     for i in range(1, len(HAND) + 1):
-        print('>>> ' + str(i) + ': ' + str(HAND[i-1].info()))
-    print('')
-    print('The cards on the mesa are:')
+        print(">>> " + str(i) + ": " + str(HAND[i-1].info()))
+    print("")
+    print("The cards on the mesa are:")
     MESA = RONDA.current_mesa
     for i in range(1, len(MESA) + 1):
-        print('>>> ' + str(i) + ': ' + str(MESA[i-1].info()))
-    print('...')
+        print(">>> " + str(i) + ": " + str(MESA[i-1].info()))
+    print("...")
 
     # Play a card from the hand
-    if PLAYERNAME == 'Alice':
+    if PLAYERNAME == "Alice":
         (OWN_CARD, MESA_CARDS) = getchoices(HAND, RONDA.current_mesa)
     else:
-        CUR_PLAYER_HAND = RONDA.player_cards[PLAYER]['hand']
+        CUR_PLAYER_HAND = RONDA.player_cards[PLAYER]["hand"]
         (OWN_CARD, MESA_CARDS) = PLAYER.get_move(CUR_PLAYER_HAND, MESA)
 
     if MESA_CARDS:
-        MSG = f'{PLAYERNAME} plays a {OWN_CARD} and picks up {MESA_CARDS}'
+        MSG = f"{PLAYERNAME} plays a {OWN_CARD} and picks up {MESA_CARDS}"
     else:
-        MSG = PLAYERNAME + ' drops a ' + str(OWN_CARD)
+        MSG = PLAYERNAME + " drops a " + str(OWN_CARD)
     print(MSG)
 
     RONDA = RONDA.play_turn(OWN_CARD, MESA_CARDS)
-    print('.')
+    print(".")
 
     if (RONDA.current_player == CHARLIE) \
-            and (len(RONDA.player_cards[CHARLIE]['hand']) == 3):
-        print('///////////////////////////')
-        print('     Dealing cards . . .')
-        print('///////////////////////////')
+            and (len(RONDA.player_cards[CHARLIE]["hand"]) == 3):
+        print("///////////////////////////")
+        print("     Dealing cards . . .")
+        print("///////////////////////////")
 
-print('Ronda finished!')
-print('')
+print("Ronda finished!")
+print("")
 
 SCORES = RONDA.calculate_scores()
 
-print('-------PUNTUAJE----------')
+print("-------PUNTUAJE----------")
 for key in SCORES:
-    print(key + ':\t' + str(SCORES[key]))
+    print(key + ":\t" + str(SCORES[key]))

--- a/quince/ui/components/about.py
+++ b/quince/ui/components/about.py
@@ -45,7 +45,7 @@ class AboutFactory(object):
                         cursor="hand2",
                         )
         link.pack(pady=pady, padx=padx)
-        link.bind('<Button-1>', open_link)
+        link.bind("<Button-1>", open_link)
 
         ok_btn = tk.Button(window, text="Close", command=window.destroy)
         ok_btn.pack(pady=15, padx=padx)

--- a/quince/ui/components/common/avatar.py
+++ b/quince/ui/components/common/avatar.py
@@ -34,7 +34,7 @@ class PlayerAvatar(tk.Frame):
         image.thumbnail((65, 65), Image.ANTIALIAS)
         img = ImageTk.PhotoImage(image)
 
-        self.img_label = tk.Label(self, image=img, relief='solid')
+        self.img_label = tk.Label(self, image=img, relief="solid")
         self.img_label.image = img  # hold on to the reference
 
         self.label = tk.Label(self, text=player_name)

--- a/quince/ui/components/game_app.py
+++ b/quince/ui/components/game_app.py
@@ -20,15 +20,15 @@ class GameApp(tk.Tk):
         self.frames = {}
 
         self.about_factory = AboutFactory
-        self.frames['TopMenu'] = TopMenuFactory.generate(self.container,
+        self.frames["TopMenu"] = TopMenuFactory.generate(self.container,
                                                          self._start_new_game)
-        self.frames['TopMenu'].grid(row=0, column=0, sticky="nsew")
+        self.frames["TopMenu"].grid(row=0, column=0, sticky="nsew")
 
-        self.frames['scores'] = ScoreReport.generate(self.container)
-        self.frames['scores'].grid(row=0, column=0, sticky="nsew")
+        self.frames["scores"] = ScoreReport.generate(self.container)
+        self.frames["scores"].grid(row=0, column=0, sticky="nsew")
 
         self._build_menus()
-        self.show_frame('TopMenu')
+        self.show_frame("TopMenu")
 
     def _start_new_game(self, game_frame_factory):
         previous_game = self.frames.get("GameFrame", None)
@@ -38,9 +38,9 @@ class GameApp(tk.Tk):
 
         frame = game_frame_factory.generate(self.container,
                                             self.display_scores)
-        self.frames['GameFrame'] = frame
+        self.frames["GameFrame"] = frame
         frame.grid(row=0, column=0, sticky="nsew")
-        self.show_frame('GameFrame')
+        self.show_frame("GameFrame")
 
     def show_frame(self, controller):
         """
@@ -70,7 +70,7 @@ class GameApp(tk.Tk):
         menubar.add_cascade(label="Help", menu=helpmenu)
 
         # probably unnecessary, but here for legacy compatibility
-        self.option_add('*tearOff', tk.FALSE)
+        self.option_add("*tearOff", tk.FALSE)
         self.config(menu=menubar)
 
     def _show_about(self):
@@ -79,5 +79,5 @@ class GameApp(tk.Tk):
     def display_scores(self, ronda):
         """Updates and brings up the scores panel.
         """
-        self.frames['scores'].update_scores(ronda)
-        self.show_frame('scores')
+        self.frames["scores"].update_scores(ronda)
+        self.show_frame("scores")

--- a/quince/ui/components/game_frame.py
+++ b/quince/ui/components/game_frame.py
@@ -51,7 +51,7 @@ class GameFrame(tk.Frame):
                                  self.npc3)
 
         # OPPONENT 1
-        opp1_hand_size = len(self.ronda.player_cards[self.npc1]['hand'])
+        opp1_hand_size = len(self.ronda.player_cards[self.npc1]["hand"])
         opp1_active = self.ronda.current_player is self.npc1
         self.opp1 = OpponentFrameVertical(self,
                                           self.npc1.image(),
@@ -62,7 +62,7 @@ class GameFrame(tk.Frame):
 
         # OPPONENT 2
         opp2_active = self.ronda.current_player is self.npc2
-        opp2_hand_size = len(self.ronda.player_cards[self.npc2]['hand'])
+        opp2_hand_size = len(self.ronda.player_cards[self.npc2]["hand"])
         self.opp2 = OpponentFrameHorizontal(self,
                                             self.npc2.image(),
                                             self.npc2.name(),
@@ -72,7 +72,7 @@ class GameFrame(tk.Frame):
 
         # OPPONENT 3
         opp3_active = self.ronda.current_player is self.npc3
-        opp3_hand_size = len(self.ronda.player_cards[self.npc3]['hand'])
+        opp3_hand_size = len(self.ronda.player_cards[self.npc3]["hand"])
         self.opp3 = OpponentFrameVertical(self,
                                           self.npc3.image(),
                                           self.npc3.name(),
@@ -81,7 +81,7 @@ class GameFrame(tk.Frame):
         self.opp3.grid(row=1, column=2)
 
         # PLAYER
-        myhand = self.ronda.player_cards[self.player]['hand']
+        myhand = self.ronda.player_cards[self.player]["hand"]
         player_is_active = self.ronda.current_player is self.player
         self.hud = PlayerFrame(self,
                                self.player,
@@ -103,22 +103,22 @@ class GameFrame(tk.Frame):
         current_player = self.ronda.current_player
 
         # OPPONENT 1
-        opp1_hand_size = len(self.ronda.player_cards[self.npc1]['hand'])
+        opp1_hand_size = len(self.ronda.player_cards[self.npc1]["hand"])
         opp1_active = self.ronda.current_player is self.npc1
         self.opp1.refresh(opp1_hand_size, opp1_active)
 
         # OPPONENT 2
         opp2_active = current_player is self.npc2
-        opp2_hand_size = len(self.ronda.player_cards[self.npc2]['hand'])
+        opp2_hand_size = len(self.ronda.player_cards[self.npc2]["hand"])
         self.opp2.refresh(opp2_hand_size, opp2_active)
 
         # OPPONENT 3
         opp3_active = current_player is self.npc3
-        opp3_hand_size = len(self.ronda.player_cards[self.npc3]['hand'])
+        opp3_hand_size = len(self.ronda.player_cards[self.npc3]["hand"])
         self.opp3.refresh(opp3_hand_size, opp3_active)
 
         # PLAYER
-        myhand = self.ronda.player_cards[self.player]['hand']
+        myhand = self.ronda.player_cards[self.player]["hand"]
         player_is_active = current_player is self.player
         self.hud.refresh(myhand, player_is_active)
 
@@ -145,8 +145,8 @@ class GameFrame(tk.Frame):
         player clicks the "Play Hand" button.
         """
         if self.ronda.current_player is self.player:
-            print(f'Attempting to play {hand_card} and\
-                pick up: {self.selected_table_cards}')
+            print(f"Attempting to play {hand_card} and\
+                pick up: {self.selected_table_cards}")
 
             if is_valid_pickup(hand_card, self.selected_table_cards):
                 self.ronda = self.ronda.play_turn(hand_card,
@@ -175,11 +175,11 @@ class GameFrame(tk.Frame):
     def _play_cpu_move(self):
         table_cards = self.ronda.current_mesa
         current_player = self.ronda.current_player
-        hand = self.ronda.player_cards[current_player]['hand']
+        hand = self.ronda.player_cards[current_player]["hand"]
         (own_card, mesa_cards) = current_player.get_move(hand, table_cards)
 
         self.ronda = self.ronda.play_turn(own_card, mesa_cards)
-        print(f'{current_player.name()}\
-            played: {own_card} and picked up: {mesa_cards}')
+        print(f"{current_player.name()}\
+            played: {own_card} and picked up: {mesa_cards}")
         self.draw()
         self.play_next_move()

--- a/quince/ui/components/game_frame_factory.py
+++ b/quince/ui/components/game_frame_factory.py
@@ -19,7 +19,7 @@ class GameFrameFactory(object):
         self.npc3 = npc3
 
     def generate(self, root, callback):
-        """Generates a GameFrame object whose parent Tk widget is 'root'.
+        """Generates a GameFrame object whose parent Tk widget is "root".
 
         Args:
             root (Tk widget)

--- a/quince/ui/components/opponents/hand.py
+++ b/quince/ui/components/opponents/hand.py
@@ -38,7 +38,7 @@ class OpponentHand(tk.Frame):
         Args:
             card_count (int) - Number of cards currently in hand
         """
-        relpath = f'quince/ui/assets/opponent_hands/cards_{card_count}.png'
+        relpath = f"quince/ui/assets/opponent_hands/cards_{card_count}.png"
         image_path = os.path.join(os.getcwd(), relpath)
         image = Image.open(image_path)
         image.thumbnail((self.image_size, self.image_size), Image.ANTIALIAS)

--- a/quince/ui/components/player/player_frame.py
+++ b/quince/ui/components/player/player_frame.py
@@ -64,7 +64,7 @@ class PlayerFrame(tk.Frame):
         """
         self.avatar.refresh(is_active)
 
-        btn_state = 'normal' if is_active else 'disabled'
+        btn_state = "normal" if is_active else "disabled"
         self.play_hand_btn.config(state=btn_state)
 
         self.p_hand.destroy()

--- a/quince/ui/components/score_report/card_scroll.py
+++ b/quince/ui/components/score_report/card_scroll.py
@@ -15,7 +15,7 @@ class CardScroll(tk.Frame):
         player_image.thumbnail((65, 65), Image.ANTIALIAS)
         img = ImageTk.PhotoImage(player_image)
 
-        img_label = tk.Label(self, image=img, relief='solid')
+        img_label = tk.Label(self, image=img, relief="solid")
         img_label.image = img
         img_label.grid(row=0, column=0, padx=10, sticky="we", rowspan=2)
 

--- a/quince/ui/components/score_report/score_report.py
+++ b/quince/ui/components/score_report/score_report.py
@@ -55,28 +55,28 @@ class ScoreReport(tk.Frame):
     def update_scores(self, ronda):
         scores = ronda.calculate_scores()
 
-        siete = scores.get('7_de_velo', "Score Error")
+        siete = scores.get("7_de_velo", "Score Error")
         self.siete.config(text=siete)
 
-        most_cards = scores.get('most_cards', "Score Error")
+        most_cards = scores.get("most_cards", "Score Error")
         self.most_cards.config(text=most_cards)
 
-        most_oros = scores.get('most_oros', "Score Error")
+        most_oros = scores.get("most_oros", "Score Error")
         self.most_oros.config(text=most_oros)
 
-        setenta = scores.get('setenta', "Score Error")
+        setenta = scores.get("setenta", "Score Error")
         self.setenta.config(text=setenta)
 
-        escobas = scores.get('escobas', 'Score Error')
+        escobas = scores.get("escobas", "Score Error")
         self.escobas.config(text=escobas)
 
         # This will blow up when we try to update scores after
         # more than one ronda
         row = 6
         for player in ronda.player_cards:
-            pila = ronda.player_cards[player]['pila']
+            pila = ronda.player_cards[player]["pila"]
             C = pila.get_cards()
-            cards = C['oro'] + C['copa'] + C['espada'] + C['basto']
+            cards = C["oro"] + C["copa"] + C["espada"] + C["basto"]
             scroll = CardScroll(self, player.image(), cards)
             scroll.grid(row=row,
                         column=0,

--- a/quince/ui/components/top_menu/top_menu.py
+++ b/quince/ui/components/top_menu/top_menu.py
@@ -98,10 +98,10 @@ class TopMenu(tk.Frame):
         user = Player(self.name_entry.get())
         user.image_path = self.avatar_path
 
-        path = os.path.join(os.getcwd(), 'quince/ui/assets/avatars')
-        npc1 = NPC('Roberto', f'{path}/avatar06.png')
-        npc2 = NPC('Gus', f'{path}/avatar08.png')
-        npc3 = NPC('Diana', f'{path}/avatar07.png')
+        path = os.path.join(os.getcwd(), "quince/ui/assets/avatars")
+        npc1 = NPC("Roberto", f"{path}/avatar06.png")
+        npc2 = NPC("Gus", f"{path}/avatar08.png")
+        npc3 = NPC("Diana", f"{path}/avatar07.png")
         game_frame_factory = GameFrameFactory(user, npc1, npc2, npc3)
 
         self.start_game(game_frame_factory)

--- a/quince/ui/components/top_menu/validating_entry.py
+++ b/quince/ui/components/top_menu/validating_entry.py
@@ -9,8 +9,8 @@ def select_all(event):
     Args:
         event - Tkinter binding event
     """
-    event.widget.select_range(0, 'end')
-    event.widget.icursor('end')
+    event.widget.select_range(0, "end")
+    event.widget.icursor("end")
     return "break"
 
 

--- a/quince/utility.py
+++ b/quince/utility.py
@@ -1,3 +1,8 @@
+"""
+
+Contains utility functions and classes used throughout project.
+"""
+
 def is_valid_pickup(player_card, mesa_cards):
     """Determines whether a move is valid.
 

--- a/quince/utility.py
+++ b/quince/utility.py
@@ -3,6 +3,7 @@
 Contains utility functions and classes used throughout project.
 """
 
+
 def is_valid_pickup(player_card, mesa_cards):
     """Determines whether a move is valid.
 

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,16 @@
 
 from setuptools import setup
 
-with open('README.md' 'r') as fh:
+with open("README.md" "r") as fh:
     long_description = fh.read()
 
-setup(name='Quince',
-      version='1.0',
-      description='Classic Spanish card game.',
+setup(name="Quince",
+      version="1.0",
+      description="Classic Spanish card game.",
       long_description=long_description,
       long_description_content_type="text/markdown",
-      author='Dan Liberatori',
-      author_email='daniel.liberatori@gmail.com',
-      url='http://www.danliberatori.com',
-      packages=['quince', 'ui']
+      author="Dan Liberatori",
+      author_email="daniel.liberatori@gmail.com",
+      url="http://www.danliberatori.com",
+      packages=["quince", "ui"]
       )

--- a/test/components/test_card.py
+++ b/test/components/test_card.py
@@ -5,44 +5,44 @@ from quince.components import Card
 class TestCard(unittest.TestCase):
     def test_info(self):
         """Returns a tuple containing suit and number"""
-        c = Card(4, 'basto')
-        self.assertEqual((4, 'basto'), c.info())
+        c = Card(4, "basto")
+        self.assertEqual((4, "basto"), c.info())
 
         # Check that an error is raised on an invalid number
         with self.assertRaises(ValueError):
-            c = Card(13, 'espada')
+            c = Card(13, "espada")
 
     def test_clone(self):
         """Clones a card"""
-        c = Card(1, 'oro')
+        c = Card(1, "oro")
         d = c.clone()
 
         # Modifying this private attribute just for the purposes of testing
         c._number = 3
-        self.assertEqual((1, 'oro'), d.info())
+        self.assertEqual((1, "oro"), d.info())
 
     @unittest.skip("Not implemented")
     def test_image(self):
         """Returns an image for the card"""
-        card = Card(10, 'oro') # noqa
+        card = Card(10, "oro") # noqa
 
-        self.fail('Failed')
+        self.fail("Failed")
 
     def test_points_setenta(self):
         """The number of points a card is worth in the setenta"""
-        c = Card(7, 'oro')
+        c = Card(7, "oro")
         self.assertTrue(10, c.points_setenta)
 
     def test_str(self):
         """String representation"""
-        c = Card(1, 'oro')
+        c = Card(1, "oro")
         s = str(c)
-        self.assertTrue('1' in s)
-        self.assertTrue('oro' in s)
+        self.assertTrue("1" in s)
+        self.assertTrue("oro" in s)
 
     def test_repr(self):
         """String representation"""
-        c = Card(1, 'oro')
+        c = Card(1, "oro")
         s = repr(c)
-        self.assertTrue('1' in s)
-        self.assertTrue('oro' in s)
+        self.assertTrue("1" in s)
+        self.assertTrue("oro" in s)

--- a/test/components/test_deck.py
+++ b/test/components/test_deck.py
@@ -9,11 +9,11 @@ class TestDeck(unittest.TestCase):
         self.assertEqual(40, len(deck.cards()))
 
         # Assert that there are no duplicate cards in the deck
-        deck_check = {'oro': [], 'espada': [], 'copa': [], 'basto': []}
+        deck_check = {"oro": [], "espada": [], "copa": [], "basto": []}
         for card in deck.cards():
             (number, palo) = card.info()
             if number in deck_check[palo]:
-                self.fail('Duplicate card in deck')
+                self.fail("Duplicate card in deck")
             else:
                 deck_check[palo].append(number)
 
@@ -21,7 +21,7 @@ class TestDeck(unittest.TestCase):
         for palo in deck_check:
             for i in range(1, 11):
                 if i not in deck_check[palo]:
-                    self.fail('Missing ' + str(i) + ' in ' + palo)
+                    self.fail("Missing " + str(i) + " in " + palo)
 
     def test_cards(self):
         """Returns a copy of the deck"""
@@ -45,14 +45,14 @@ class TestDeck(unittest.TestCase):
         """String representation"""
         d = Deck(Card)
         s = str(d)
-        self.assertTrue('40' in s)
+        self.assertTrue("40" in s)
 
     def test_repr(self):
         """String representation"""
         d = Deck(Card)
         d.deal(4)
         s = repr(d)
-        self.assertTrue('36' in s)
+        self.assertTrue("36" in s)
 
     def test_generate_clone(self):
         """Builds a clone of an existing deck, if one is passed."""

--- a/test/components/test_pila.py
+++ b/test/components/test_pila.py
@@ -6,29 +6,29 @@ class TestPila(unittest.TestCase):
     def test_add(self):
         """Add cards to the pila, and retrieve them"""
         pila = Pila()
-        card1 = Card(4, 'basto')
-        card2 = Card(6, 'basto')
-        card3 = Card(6, 'oro')
-        card4 = Card(1, 'espada')
+        card1 = Card(4, "basto")
+        card2 = Card(6, "basto")
+        card3 = Card(6, "oro")
+        card4 = Card(1, "espada")
 
         pila2 = pila.add([card1, card2])
         current_cards = pila2.get_cards()
-        self.assertEqual(2, len(current_cards['basto']))
-        self.assertEqual(0, len(current_cards['oro']))
-        self.assertEqual(0, len(current_cards['espada']))
-        self.assertEqual(0, len(current_cards['copa']))
+        self.assertEqual(2, len(current_cards["basto"]))
+        self.assertEqual(0, len(current_cards["oro"]))
+        self.assertEqual(0, len(current_cards["espada"]))
+        self.assertEqual(0, len(current_cards["copa"]))
 
         pila3 = pila2.add([card3, card4])
         current_cards = pila3.get_cards()
-        self.assertEqual(2, len(current_cards['basto']))
-        self.assertEqual(1, len(current_cards['oro']))
-        self.assertEqual(1, len(current_cards['espada']))
-        self.assertEqual(0, len(current_cards['copa']))
+        self.assertEqual(2, len(current_cards["basto"]))
+        self.assertEqual(1, len(current_cards["oro"]))
+        self.assertEqual(1, len(current_cards["espada"]))
+        self.assertEqual(0, len(current_cards["copa"]))
 
     def test_add_does_not_modify(self):
         """Returns a new pila, and does not modify the existing one"""
         pila1 = Pila()
-        card1 = Card(3, 'basto')
+        card1 = Card(3, "basto")
         pila2 = pila1.add([card1])
         self.assertEqual(0, pila1.total_cards())
         self.assertEqual(1, pila2.total_cards())
@@ -37,8 +37,8 @@ class TestPila(unittest.TestCase):
         pila = Pila()
         self.assertEqual(0, pila.escobas)
 
-        card1 = Card(7, 'oro')
-        card2 = Card(8, 'copa')
+        card1 = Card(7, "oro")
+        card2 = Card(8, "copa")
         pila2 = pila.add([card1, card2], True)
 
         self.assertEqual(1, pila2.escobas)
@@ -46,28 +46,28 @@ class TestPila(unittest.TestCase):
     def test_get_cards(self):
         """.get_cards() returns a copy of the dictionary"""
         pila = Pila()
-        card1 = Card(9, 'basto')
-        card2 = Card(6, 'basto')
-        card3 = Card(5, 'basto')
+        card1 = Card(9, "basto")
+        card2 = Card(6, "basto")
+        card3 = Card(5, "basto")
         pila2 = pila.add([card1, card2])
         cards = pila2.get_cards()
         # modifying the dictionary doesn't actually affect the pila
-        cards['basto'].append(card3)
+        cards["basto"].append(card3)
 
         pilaCards = pila2.get_cards()
-        self.assertEqual(2, len(pilaCards['basto']))
+        self.assertEqual(2, len(pilaCards["basto"]))
 
     def test_total_cards(self):
         """Counts the total number of cards the player has picked up."""
         pila = Pila()
         self.assertEqual(0, pila.total_cards())
 
-        card1 = Card(9, 'basto')
-        card2 = Card(6, 'basto')
-        card3 = Card(5, 'espada')
-        card4 = Card(1, 'oro')
-        card5 = Card(3, 'copa')
-        card6 = Card(5, 'espada')
+        card1 = Card(9, "basto")
+        card2 = Card(6, "basto")
+        card3 = Card(5, "espada")
+        card4 = Card(1, "oro")
+        card5 = Card(3, "copa")
+        card6 = Card(5, "espada")
         pila2 = pila.add([card1, card2])
         self.assertEqual(2, pila2.total_cards())
 
@@ -81,11 +81,11 @@ class TestPila(unittest.TestCase):
         """Counts the total number of oros collected by the player"""
         pila = Pila()
         self.assertEqual(0, pila.total_oros())
-        card1 = Card(9, 'basto')
-        card2 = Card(5, 'espada')
-        card3 = Card(1, 'oro')
-        card4 = Card(10, 'oro')
-        card5 = Card(10, 'copa')
+        card1 = Card(9, "basto")
+        card2 = Card(5, "espada")
+        card3 = Card(1, "oro")
+        card4 = Card(10, "oro")
+        card5 = Card(10, "copa")
         pila2 = pila.add([card1, card2])
         self.assertEqual(0, pila2.total_oros())
 
@@ -98,12 +98,12 @@ class TestPila(unittest.TestCase):
     def test_has_siete_de_velo(self):
         """Checks whether the 7 de velo is in the pile"""
         pila = Pila()
-        card1 = Card(9, 'basto')
-        card2 = Card(5, 'espada')
-        card3 = Card(1, 'oro')
-        card4 = Card(7, 'oro')
-        card5 = Card(8, 'oro')
-        card6 = Card(7, 'espada')
+        card1 = Card(9, "basto")
+        card2 = Card(5, "espada")
+        card3 = Card(1, "oro")
+        card4 = Card(7, "oro")
+        card5 = Card(8, "oro")
+        card6 = Card(7, "espada")
 
         pila2 = pila.add([card1, card2, card3])
         self.assertFalse(pila2.has_siete_de_velo())
@@ -115,11 +115,11 @@ class TestPila(unittest.TestCase):
         self.assertTrue(pila4.has_siete_de_velo())
 
     def test_best_setenta(self):
-        basto4 = Card(4, 'basto')
-        oro7 = Card(7, 'oro')
-        espada10 = Card(10, 'espada')
-        copa1 = Card(1, 'copa')
-        copa5 = Card(5, 'copa')
+        basto4 = Card(4, "basto")
+        oro7 = Card(7, "oro")
+        espada10 = Card(10, "espada")
+        copa1 = Card(1, "copa")
+        copa5 = Card(5, "copa")
 
         # Only one option
         pila1 = Pila()
@@ -137,12 +137,12 @@ class TestPila(unittest.TestCase):
         self.assertFalse(setenta)
 
     def test_best_setenta2(self):
-        basto4 = Card(4, 'basto')
-        oro7 = Card(7, 'oro')
-        oro4 = Card(4, 'oro')
-        espada10 = Card(10, 'espada')
-        copa1 = Card(1, 'copa')
-        copa5 = Card(5, 'copa')
+        basto4 = Card(4, "basto")
+        oro7 = Card(7, "oro")
+        oro4 = Card(4, "oro")
+        espada10 = Card(10, "espada")
+        copa1 = Card(1, "copa")
+        copa5 = Card(5, "copa")
 
         pila1 = Pila()
         pila2 = pila1.add([basto4, oro7, espada10, copa5, copa1])

--- a/test/components/test_player.py
+++ b/test/components/test_player.py
@@ -5,22 +5,22 @@ from quince.components import Card, Player, NPC
 class TestPlayer(unittest.TestCase):
     def test_id(self):
         """Initialize different players with different ids"""
-        a = Player('Alice')
-        b = Player('Alice')
+        a = Player("Alice")
+        b = Player("Alice")
         self.assertTrue(a.id + 1 == b.id)
 
     def test_name(self):
         """Getter for the player's name"""
-        alice = Player('Alice')
-        self.assertEqual('Alice', alice.name())
+        alice = Player("Alice")
+        self.assertEqual("Alice", alice.name())
 
     def test_total_score(self):
         """Getter for the player's score"""
-        alice = Player('Alice')
+        alice = Player("Alice")
         self.assertEqual(0, alice.total_score())
 
     def test_award_points(self):
-        p = Player('Alice')
+        p = Player("Alice")
         # Award 1 point by default
         p.award_points()
         self.assertEqual(1, p.total_score())
@@ -30,15 +30,15 @@ class TestPlayer(unittest.TestCase):
 
     def test_str(self):
         """String representation"""
-        p = Player('Annie')
+        p = Player("Annie")
         s = str(p)
-        self.assertTrue('Annie' in s)
+        self.assertTrue("Annie" in s)
 
     def test_repr(self):
         """String representation"""
-        p = Player('Billy')
+        p = Player("Billy")
         s = repr(p)
-        self.assertTrue('Billy' in s)
+        self.assertTrue("Billy" in s)
 
 
 class TestNPC(unittest.TestCase):
@@ -46,8 +46,8 @@ class TestNPC(unittest.TestCase):
         """Given a hand and a mesa,
         select which cards to play and what to pick up."""
         npc = NPC()
-        a = Card(5, 'oro')
-        b = Card(10, 'oro')
+        a = Card(5, "oro")
+        b = Card(10, "oro")
         hand = [a]
         mesa = [b]
         (from_hand, from_mesa) = npc.get_move(hand, mesa)
@@ -57,10 +57,10 @@ class TestNPC(unittest.TestCase):
     def test_get_move_no_choice(self):
         """Drop a card if there are no moves available."""
         npc = NPC()
-        a = Card(1, 'oro')
-        b = Card(1, 'basto')
-        c = Card(9, 'copa')
-        d = Card(8, 'espada')
+        a = Card(1, "oro")
+        b = Card(1, "basto")
+        c = Card(9, "copa")
+        d = Card(8, "espada")
         hand = [a]
         mesa = [b, c, d]
         (from_hand, from_mesa) = npc.get_move(hand, mesa)

--- a/test/ronda/test_pointscounters.py
+++ b/test/ronda/test_pointscounters.py
@@ -7,52 +7,52 @@ class TestPointsCounter(unittest.TestCase):
     def test_compare(self):
         pc = PointsCounter()
         # Single player automatically becomes the top scorer
-        pc.compare('alice', 10)
-        self.assertTrue('alice' in pc.winners)
+        pc.compare("alice", 10)
+        self.assertTrue("alice" in pc.winners)
 
         # Tied scores are all winners
-        pc.compare('bob', 10)
-        self.assertTrue('alice' in pc.winners)
-        self.assertTrue('bob' in pc.winners)
+        pc.compare("bob", 10)
+        self.assertTrue("alice" in pc.winners)
+        self.assertTrue("bob" in pc.winners)
 
         # Bigger scores override all others
-        pc.compare('charlie', 11)
-        pc.compare('dave', 3)
-        self.assertTrue('alice' not in pc.winners)
-        self.assertTrue('bob' not in pc.winners)
-        self.assertTrue('dave' not in pc.winners)
-        self.assertTrue('charlie' in pc.winners)
+        pc.compare("charlie", 11)
+        pc.compare("dave", 3)
+        self.assertTrue("alice" not in pc.winners)
+        self.assertTrue("bob" not in pc.winners)
+        self.assertTrue("dave" not in pc.winners)
+        self.assertTrue("charlie" in pc.winners)
 
 
 class TestSetentaCounter(unittest.TestCase):
     def test_compare(self):
         pc = SetentaCounter()
-        a_hand = [Card(5, 'oro'), Card(6, 'basto'),
-                  Card(4, 'espada'), Card(6, 'copa')]
-        b_hand = [Card(2, 'oro'), Card(2, 'basto'),
-                  Card(5, 'espada'), Card(2, 'copa')]
-        c_hand = [Card(6, 'oro'), Card(1, 'basto'),
-                  Card(6, 'espada'), Card(7, 'copa')]
+        a_hand = [Card(5, "oro"), Card(6, "basto"),
+                  Card(4, "espada"), Card(6, "copa")]
+        b_hand = [Card(2, "oro"), Card(2, "basto"),
+                  Card(5, "espada"), Card(2, "copa")]
+        c_hand = [Card(6, "oro"), Card(1, "basto"),
+                  Card(6, "espada"), Card(7, "copa")]
 
-        pc.compare('alice', a_hand)
-        self.assertTrue('alice' in [x.player for x in pc.winners])
+        pc.compare("alice", a_hand)
+        self.assertTrue("alice" in [x.player for x in pc.winners])
 
-        pc.compare('bob', b_hand)
-        self.assertTrue('alice' in [x.player for x in pc.winners])
-        self.assertTrue('bob' not in [x.player for x in pc.winners])
+        pc.compare("bob", b_hand)
+        self.assertTrue("alice" in [x.player for x in pc.winners])
+        self.assertTrue("bob" not in [x.player for x in pc.winners])
 
-        pc.compare('charlie', c_hand)
-        self.assertTrue('alice' not in [x.player for x in pc.winners])
-        self.assertTrue('bob' not in [x.player for x in pc.winners])
-        self.assertTrue('charlie' in [x.player for x in pc.winners])
+        pc.compare("charlie", c_hand)
+        self.assertTrue("alice" not in [x.player for x in pc.winners])
+        self.assertTrue("bob" not in [x.player for x in pc.winners])
+        self.assertTrue("charlie" in [x.player for x in pc.winners])
 
     def test_four_suits_required(self):
         pc = SetentaCounter()
-        a_hand = [Card(7, 'oro'), Card(7, 'basto'), Card(7, 'espada')]
-        b_hand = [Card(2, 'oro'), Card(2, 'basto'),
-                  Card(2, 'espada'), Card(2, 'copa')]
+        a_hand = [Card(7, "oro"), Card(7, "basto"), Card(7, "espada")]
+        b_hand = [Card(2, "oro"), Card(2, "basto"),
+                  Card(2, "espada"), Card(2, "copa")]
 
-        pc.compare('alice', a_hand)
-        pc.compare('bob', b_hand)
-        self.assertTrue('alice' not in [x.player for x in pc.winners])
-        self.assertTrue('bob' in [x.player for x in pc.winners])
+        pc.compare("alice", a_hand)
+        pc.compare("bob", b_hand)
+        self.assertTrue("alice" not in [x.player for x in pc.winners])
+        self.assertTrue("bob" in [x.player for x in pc.winners])

--- a/test/ronda/test_ronda.py
+++ b/test/ronda/test_ronda.py
@@ -6,24 +6,24 @@ from quince.ronda import Ronda
 
 class TestRonda(unittest.TestCase):
     def test_instantiate(self):
-        alice = Player('Alice')
-        bob = Player('bob')
+        alice = Player("Alice")
+        bob = Player("bob")
 
         deck = Deck(Card)
 
         player_cards = {
-            alice: {'hand': [], 'pila': Pila()},
-            bob: {'hand': [], 'pila': Pila()},
+            alice: {"hand": [], "pila": Pila()},
+            bob: {"hand": [], "pila": Pila()},
         }
 
         ronda = Ronda(**{
-            'current_player': bob,
-            'dealer': alice,
-            'deck': deck,
-            'last_pickup': bob,
-            'mesa': [],
-            'players': [alice, bob],
-            'player_cards': player_cards
+            "current_player": bob,
+            "dealer": alice,
+            "deck": deck,
+            "last_pickup": bob,
+            "mesa": [],
+            "players": [alice, bob],
+            "player_cards": player_cards
         })
 
         self.assertTrue(isinstance(ronda, Ronda))
@@ -31,8 +31,8 @@ class TestRonda(unittest.TestCase):
     def test_start(self):
         random.seed(0)
 
-        alice = Player('Alice')
-        bob = Player('Bob')
+        alice = Player("Alice")
+        bob = Player("Bob")
         ronda = Ronda.start([alice, bob], alice)
         self.assertTrue(isinstance(ronda, Ronda))
 
@@ -42,7 +42,7 @@ class TestRonda(unittest.TestCase):
 
         # Each player has three cards
         for val in ronda._player_cards.values():
-            self.assertEqual(3, len(val['hand']))
+            self.assertEqual(3, len(val["hand"]))
 
         # The table has four cards
         self.assertEqual(4, len(ronda.current_mesa))
@@ -50,229 +50,229 @@ class TestRonda(unittest.TestCase):
     def test_start_with_escoba(self):
         random.seed(27)
 
-        alice = Player('Alice')
-        bob = Player('Bob')
+        alice = Player("Alice")
+        bob = Player("Bob")
         ronda = Ronda.start([alice, bob], alice)
         self.assertFalse(ronda.current_mesa)
 
-        alice_pila = ronda._player_cards[alice]['pila']
+        alice_pila = ronda._player_cards[alice]["pila"]
         self.assertEqual(4, alice_pila.total_cards())
 
     def test_play_turn(self):
         random.seed(0)
 
-        alice = Player('Alice')
-        bob = Player('Bob')
+        alice = Player("Alice")
+        bob = Player("Bob")
         ronda = Ronda.start([alice, bob], alice)
-        # bob holds: [(6, 'basto'), (8, 'basto'), (4, 'copa')]
-        # alice holds: [(1, 'oro'), (7, 'copa'), (4, 'oro')]
-        # on table: [(10, 'espada'), (9, 'espada'), (1, 'basto'), (6, 'oro')]
+        # bob holds: [(6, "basto"), (8, "basto"), (4, "copa")]
+        # alice holds: [(1, "oro"), (7, "copa"), (4, "oro")]
+        # on table: [(10, "espada"), (9, "espada"), (1, "basto"), (6, "oro")]
 
         # bob drops a card
-        ronda2 = ronda.play_turn(Card(8, 'basto'))
-        self.assertTrue(Card(8, 'basto') in ronda._player_cards[bob]['hand'])
-        self.assertTrue(Card(8, 'basto')
-                        not in ronda2._player_cards[bob]['hand'])
+        ronda2 = ronda.play_turn(Card(8, "basto"))
+        self.assertTrue(Card(8, "basto") in ronda._player_cards[bob]["hand"])
+        self.assertTrue(Card(8, "basto")
+                        not in ronda2._player_cards[bob]["hand"])
 
     def test_play_turn2(self):
         random.seed(0)
 
-        alice = Player('Alice')
-        bob = Player('Bob')
+        alice = Player("Alice")
+        bob = Player("Bob")
         ronda = Ronda.start([alice, bob], alice)
-        # bob holds: [(6, 'basto'), (8, 'basto'), (4, 'copa')]
-        # alice holds: [(1, 'oro'), (7, 'copa'), (4, 'oro')]
-        # on table: [(10, 'espada'), (9, 'espada'), (1, 'basto'), (6, 'oro')]
+        # bob holds: [(6, "basto"), (8, "basto"), (4, "copa")]
+        # alice holds: [(1, "oro"), (7, "copa"), (4, "oro")]
+        # on table: [(10, "espada"), (9, "espada"), (1, "basto"), (6, "oro")]
 
         # bob picks up a card
-        ronda2 = ronda.play_turn(Card(6, 'basto'), [Card(9, 'espada')])
-        self.assertTrue(Card(6, 'basto') in ronda._player_cards[bob]['hand'])
-        self.assertTrue(Card(6, 'basto')
-                        not in ronda2._player_cards[bob]['hand'])
-        self.assertTrue(Card(9, 'espada') not in ronda2.current_mesa)
+        ronda2 = ronda.play_turn(Card(6, "basto"), [Card(9, "espada")])
+        self.assertTrue(Card(6, "basto") in ronda._player_cards[bob]["hand"])
+        self.assertTrue(Card(6, "basto")
+                        not in ronda2._player_cards[bob]["hand"])
+        self.assertTrue(Card(9, "espada") not in ronda2.current_mesa)
 
     def test_hand_is_done(self):
-        alice = Player('alice')
-        bob = Player('Bob')
+        alice = Player("alice")
+        bob = Player("Bob")
         ronda = Ronda.start([alice, bob], alice)
         self.assertFalse(ronda._hand_is_done)
 
-        ronda._player_cards[bob]['hand'] = []
+        ronda._player_cards[bob]["hand"] = []
         self.assertFalse(ronda._hand_is_done)
 
-        ronda._player_cards[alice]['hand'] = []
+        ronda._player_cards[alice]["hand"] = []
         self.assertTrue(ronda._hand_is_done)
 
     def test_is_finished(self):
-        alice = Player('Alice')
-        bob = Player('bob')
+        alice = Player("Alice")
+        bob = Player("bob")
 
         deck = Deck(Card).deal(40)[0]
 
         player_cards = {
-            alice: {'hand': [], 'pila': Pila()},
-            bob: {'hand': [], 'pila': Pila()},
+            alice: {"hand": [], "pila": Pila()},
+            bob: {"hand": [], "pila": Pila()},
         }
 
         ronda = Ronda(**{
-            'current_player': bob,
-            'dealer': alice,
-            'deck': deck,
-            'last_pickup': bob,
-            'mesa': [],
-            'players': [alice, bob],
-            'player_cards': player_cards
+            "current_player": bob,
+            "dealer": alice,
+            "deck": deck,
+            "last_pickup": bob,
+            "mesa": [],
+            "players": [alice, bob],
+            "player_cards": player_cards
         })
 
         self.assertTrue(ronda.is_finished)
 
     def test_count_scores(self):
-        alice = Player('Alice')
-        bob = Player('Bob')
-        charlie = Player('Charlie')
+        alice = Player("Alice")
+        bob = Player("Bob")
+        charlie = Player("Charlie")
 
-        alice_cards = [Card(1, 'espada'), Card(10, 'espada'), Card(4, 'oro'),
-                       Card(1, 'copa'), Card(9, 'basto'), Card(2, 'copa'),
-                       Card(1, 'basto'), Card(3, 'basto'),
-                       Card(8, 'copa'), Card(8, 'basto')]
-        bob_cards = [Card(6, 'copa'), Card(9, 'espada'), Card(3, 'oro'),
-                     Card(5, 'espada'), Card(7, 'basto'), Card(7, 'espada'),
-                     Card(6, 'oro'), Card(3, 'espada'), Card(8, 'espada'),
-                     Card(9, 'oro'), Card(8, 'oro'), Card(2, 'oro')]
-        charlie_cards = [Card(10, 'basto'), Card(5, 'basto'), Card(4, 'basto'),
-                         Card(9, 'copa'), Card(7, 'copa'), Card(5, 'oro'),
-                         Card(1, 'oro'), Card(2, 'basto'), Card(4, 'copa'),
-                         Card(10, 'copa'), Card(5, 'copa'), Card(4, 'espada'),
-                         Card(3, 'copa'), Card(6, 'espada'), Card(2, 'espada'),
-                         Card(7, 'oro'), Card(6, 'basto'), Card(10, 'oro')]
+        alice_cards = [Card(1, "espada"), Card(10, "espada"), Card(4, "oro"),
+                       Card(1, "copa"), Card(9, "basto"), Card(2, "copa"),
+                       Card(1, "basto"), Card(3, "basto"),
+                       Card(8, "copa"), Card(8, "basto")]
+        bob_cards = [Card(6, "copa"), Card(9, "espada"), Card(3, "oro"),
+                     Card(5, "espada"), Card(7, "basto"), Card(7, "espada"),
+                     Card(6, "oro"), Card(3, "espada"), Card(8, "espada"),
+                     Card(9, "oro"), Card(8, "oro"), Card(2, "oro")]
+        charlie_cards = [Card(10, "basto"), Card(5, "basto"), Card(4, "basto"),
+                         Card(9, "copa"), Card(7, "copa"), Card(5, "oro"),
+                         Card(1, "oro"), Card(2, "basto"), Card(4, "copa"),
+                         Card(10, "copa"), Card(5, "copa"), Card(4, "espada"),
+                         Card(3, "copa"), Card(6, "espada"), Card(2, "espada"),
+                         Card(7, "oro"), Card(6, "basto"), Card(10, "oro")]
 
         ronda = Ronda.start([alice, bob, charlie], alice)
-        ronda._player_cards[alice]['pila'] = Pila().add(alice_cards)
-        ronda._player_cards[bob]['pila'] = Pila().add(bob_cards, True)
-        ronda._player_cards[charlie]['pila'] = Pila().add(charlie_cards)
+        ronda._player_cards[alice]["pila"] = Pila().add(alice_cards)
+        ronda._player_cards[bob]["pila"] = Pila().add(bob_cards, True)
+        ronda._player_cards[charlie]["pila"] = Pila().add(charlie_cards)
 
         scores = ronda.calculate_scores()
-        (most_cards, _) = scores['most_cards']
+        (most_cards, _) = scores["most_cards"]
         self.assertTrue(charlie in most_cards)
         self.assertTrue(alice not in most_cards)
         self.assertTrue(bob not in most_cards)
 
-        (most_oros, _) = scores['most_oros']
+        (most_oros, _) = scores["most_oros"]
         self.assertTrue(bob in most_oros)
         self.assertTrue(alice not in most_oros)
         self.assertTrue(charlie not in most_oros)
 
-        siete_de_velo = scores['7_de_velo']
+        siete_de_velo = scores["7_de_velo"]
         self.assertTrue(charlie is siete_de_velo)
 
-        setenta = [x.player for x in scores['setenta']]
+        setenta = [x.player for x in scores["setenta"]]
         self.assertTrue(charlie in setenta)
         self.assertTrue(bob in setenta)
         self.assertTrue(alice not in setenta)
 
-        escobas = scores['escobas']
+        escobas = scores["escobas"]
         self.assertTrue((bob, 1) in escobas)
         self.assertEqual(1, len(escobas))
 
     def test_deal_next_hand_retain_pila(self):
         """Player retains their pila when a new hand is dealt.
         """
-        alice = Player('Alice')
-        bob = Player('Bob')
+        alice = Player("Alice")
+        bob = Player("Bob")
 
-        alice_cards = [Card(7, 'oro'), Card(8, 'oro')]
+        alice_cards = [Card(7, "oro"), Card(8, "oro")]
 
         player_cards = {}
         player_cards[alice] = {
-            'hand': [],
-            'pila': Pila().add(alice_cards)
+            "hand": [],
+            "pila": Pila().add(alice_cards)
         }
         player_cards[bob] = {
-            'hand': [],
-            'pila': Pila()
+            "hand": [],
+            "pila": Pila()
         }
 
         attributes = {
-            'current_player': bob,
-            'dealer': alice,
-            'deck': Deck(Card),
-            'last_pickup': alice,
-            'mesa': [],
-            'players': [alice, bob],
-            'player_cards': player_cards
+            "current_player": bob,
+            "dealer": alice,
+            "deck": Deck(Card),
+            "last_pickup": alice,
+            "mesa": [],
+            "players": [alice, bob],
+            "player_cards": player_cards
         }
 
         ronda = Ronda(**attributes)
-        alice_pila = ronda._player_cards[alice]['pila']
+        alice_pila = ronda._player_cards[alice]["pila"]
         alice_pila_cards = alice_pila.get_cards()
-        self.assertEqual(2, len(alice_pila_cards['oro']))
-        self.assertEqual(0, len(alice_pila_cards['copa']))
-        self.assertEqual(0, len(alice_pila_cards['espada']))
-        self.assertEqual(0, len(alice_pila_cards['basto']))
+        self.assertEqual(2, len(alice_pila_cards["oro"]))
+        self.assertEqual(0, len(alice_pila_cards["copa"]))
+        self.assertEqual(0, len(alice_pila_cards["espada"]))
+        self.assertEqual(0, len(alice_pila_cards["basto"]))
 
     def test_deal_next_hand_retain_escobas(self):
         """Players keep escobas when starting a new round."""
-        alice = Player('Alice')
-        bob = Player('Bob')
+        alice = Player("Alice")
+        bob = Player("Bob")
 
-        alice_cards = [Card(7, 'oro'), Card(8, 'oro')]
+        alice_cards = [Card(7, "oro"), Card(8, "oro")]
 
         player_cards = {}
         player_cards[alice] = {
-            'hand': [],
-            'pila': Pila().add(alice_cards, True)
+            "hand": [],
+            "pila": Pila().add(alice_cards, True)
         }
         player_cards[bob] = {
-            'hand': [],
-            'pila': Pila(escobas=4)
+            "hand": [],
+            "pila": Pila(escobas=4)
         }
 
         attributes = {
-            'current_player': bob,
-            'dealer': alice,
-            'deck': Deck(Card),
-            'last_pickup': alice,
-            'mesa': [],
-            'players': [alice, bob],
-            'player_cards': player_cards
+            "current_player": bob,
+            "dealer": alice,
+            "deck": Deck(Card),
+            "last_pickup": alice,
+            "mesa": [],
+            "players": [alice, bob],
+            "player_cards": player_cards
         }
 
         ronda = Ronda(**attributes)
-        alice_pila = ronda._player_cards[alice]['pila']
+        alice_pila = ronda._player_cards[alice]["pila"]
         alice_escobas = alice_pila.get_escobas()
         self.assertEqual(1, alice_escobas)
 
-        bob_pila = ronda._player_cards[bob]['pila']
+        bob_pila = ronda._player_cards[bob]["pila"]
         bob_escobas = bob_pila.get_escobas()
         self.assertEqual(4, bob_escobas)
 
     def test_pick_up_registers_escoba(self):
         """Players earn escobas when picking up."""
-        alice = Player('Alice')
-        bob = Player('Bob')
+        alice = Player("Alice")
+        bob = Player("Bob")
 
         player_cards = {}
         player_cards[alice] = {
-            'hand': [],
-            'pila': Pila()
+            "hand": [],
+            "pila": Pila()
         }
         player_cards[bob] = {
-            'hand': [],
-            'pila': Pila()
+            "hand": [],
+            "pila": Pila()
         }
 
-        rey = Card(10, 'oro')
+        rey = Card(10, "oro")
         attributes = {
-            'current_player': bob,
-            'dealer': alice,
-            'deck': Deck(Card),
-            'last_pickup': alice,
-            'mesa': [rey],
-            'players': [alice, bob],
-            'player_cards': player_cards
+            "current_player": bob,
+            "dealer": alice,
+            "deck": Deck(Card),
+            "last_pickup": alice,
+            "mesa": [rey],
+            "players": [alice, bob],
+            "player_cards": player_cards
         }
 
         ronda = Ronda(**attributes)
-        newronda = ronda.play_turn(Card(5, 'oro'), [rey])
-        escobas = newronda._player_cards[bob]['pila'].escobas
+        newronda = ronda.play_turn(Card(5, "oro"), [rey])
+        escobas = newronda._player_cards[bob]["pila"].escobas
         self.assertEqual(1, escobas)

--- a/test/test_cpu.py
+++ b/test/test_cpu.py
@@ -5,18 +5,18 @@ from quince.components import Card
 
 class TestCPU(unittest.TestCase):
     def test_enumerate_possibilities_drop_only(self):
-        ace = Card(1, 'oro')
-        tres = Card(3, 'oro')
-        cinco = Card(5, 'oro')
+        ace = Card(1, "oro")
+        tres = Card(3, "oro")
+        cinco = Card(5, "oro")
 
         empty_mesa = enumerate_possibilities([], [ace, cinco, tres])
         self.assertEqual([], empty_mesa)
 
     def test_enumerate_possibilities_single_choice(self):
-        cinco = Card(5, 'oro')
-        siete_velo = Card(7, 'oro')
-        sota_oro = Card(8, 'oro')
-        sota_copa = Card(8, 'copa')
+        cinco = Card(5, "oro")
+        siete_velo = Card(7, "oro")
+        sota_oro = Card(8, "oro")
+        sota_copa = Card(8, "copa")
 
         siete_sota = enumerate_possibilities([sota_oro,
                                               cinco,
@@ -28,13 +28,13 @@ class TestCPU(unittest.TestCase):
         self.assertFalse((siete_velo, cinco) in siete_sota)
 
     def test_enumerate_possibilities_multiple_choices(self):
-        ace = Card(1, 'oro')
-        tres = Card(3, 'oro')
-        cinco = Card(5, 'oro')
-        seis = Card(6, 'espada')
-        siete_velo = Card(7, 'oro')
-        sota_oro = Card(8, 'oro')
-        caballo = Card(9, 'basto')
+        ace = Card(1, "oro")
+        tres = Card(3, "oro")
+        cinco = Card(5, "oro")
+        seis = Card(6, "espada")
+        siete_velo = Card(7, "oro")
+        sota_oro = Card(8, "oro")
+        caballo = Card(9, "basto")
 
         complicated_options = enumerate_possibilities([sota_oro,
                                                        tres,
@@ -50,7 +50,7 @@ class TestCPU(unittest.TestCase):
         self.assertTrue((seis, tres, cinco, ace) in complicated_options)
 
     def test_use_only_one_from_hand(self):
-        hand = [Card(4, 'espada'), Card(4, 'basto'), Card(3, 'espada')]
-        mesa = [Card(2, 'espada'), Card(8, 'espada')]
+        hand = [Card(4, "espada"), Card(4, "basto"), Card(3, "espada")]
+        mesa = [Card(2, "espada"), Card(8, "espada")]
         must_drop = enumerate_possibilities(mesa, hand)
         self.assertFalse(must_drop)


### PR DESCRIPTION
# Overview

What does this PR do? If it addresses a specific issue, enter a # followed by the issue number you are working on.

This change was made in response to issue #18 in the repo. It's an
aesthetic change to standardize on double quotes in the code base 
and should have no effect on the actual underlying code. Care was taken
to make sure that correct usage of ( ' ) in contractions as a part of comments 
in the codebase was not changed to ( " ).

In addition, small fixes were made to get linting to 10/10 (9.8/10 previously), 
including adding a docstring to the quince.utility module and bumping part of 
line 59 to a new line to address character limit being higher than style reqs for 
one line quince.components.deck.

Test suite ran through with one skipping, but the rest passing with an "OK".

# Checklist

1. [x] Have you run the test suite? (Run `make test` in the project's root directory)
2. [x] Have you run pylint and fixed any linting errors (Run `make lint` in the project's root directory)

If your PR does not pass all its tests or lint checks, please make a note of it here, preferably with an explanation.
